### PR TITLE
Don't mask implicit mods

### DIFF
--- a/app/src/behaviors/behavior_mod_morph.c
+++ b/app/src/behaviors/behavior_mod_morph.c
@@ -46,7 +46,6 @@ static int on_mod_morph_binding_pressed(struct zmk_behavior_binding *binding,
     }
 
     if (zmk_hid_get_explicit_mods() & cfg->mods) {
-        zmk_mod_flags_t trigger_mods = zmk_hid_get_explicit_mods() & cfg->mods;
         zmk_hid_masked_modifiers_set(cfg->masked_mods);
         data->pressed_binding = (struct zmk_behavior_binding *)&cfg->morph_binding;
     } else {

--- a/app/src/behaviors/behavior_mod_morph.c
+++ b/app/src/behaviors/behavior_mod_morph.c
@@ -91,9 +91,8 @@ static int behavior_mod_morph_init(const struct device *dev) { return 0; }
         .normal_binding = _TRANSFORM_ENTRY(0, n),                                                  \
         .morph_binding = _TRANSFORM_ENTRY(1, n),                                                   \
         .mods = DT_INST_PROP(n, mods),                                                             \
-        .masked_mods = COND_CODE_0(DT_INST_NODE_HAS_PROP(n, masked_mods),                          \
-                (DT_INST_PROP(n, mods)),                                                           \
-                (DT_INST_PROP(n, masked_mods))),                                                   \
+        .masked_mods = COND_CODE_0(DT_INST_NODE_HAS_PROP(n, masked_mods), (DT_INST_PROP(n, mods)), \
+                                   (DT_INST_PROP(n, masked_mods))),                                \
     };                                                                                             \
     static struct behavior_mod_morph_data behavior_mod_morph_data_##n = {};                        \
     DEVICE_DT_INST_DEFINE(n, behavior_mod_morph_init, NULL, &behavior_mod_morph_data_##n,          \

--- a/app/src/behaviors/behavior_mod_morph.c
+++ b/app/src/behaviors/behavior_mod_morph.c
@@ -91,8 +91,9 @@ static int behavior_mod_morph_init(const struct device *dev) { return 0; }
         .normal_binding = _TRANSFORM_ENTRY(0, n),                                                  \
         .morph_binding = _TRANSFORM_ENTRY(1, n),                                                   \
         .mods = DT_INST_PROP(n, mods),                                                             \
-        .masked_mods = COND_CODE_0(DT_INST_NODE_HAS_PROP(n, masked_mods), (0),                     \
-                                   (DT_INST_PROP(n, masked_mods))),                                \
+        .masked_mods = COND_CODE_0(DT_INST_NODE_HAS_PROP(n, masked_mods),                          \
+                (DT_INST_PROP(n, mods)),                                                           \
+                (DT_INST_PROP(n, masked_mods))),                                                   \
     };                                                                                             \
     static struct behavior_mod_morph_data behavior_mod_morph_data_##n = {};                        \
     DEVICE_DT_INST_DEFINE(n, behavior_mod_morph_init, NULL, &behavior_mod_morph_data_##n,          \

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -25,7 +25,7 @@ static zmk_mod_flags_t masked_modifiers = 0;
 
 #define SET_MODIFIERS(mods)                                                                        \
     {                                                                                              \
-        keyboard_report.body.modifiers = (mods | implicit_modifiers) & ~masked_modifiers;          \
+        keyboard_report.body.modifiers = (mods & ~masked_modifiers) | implicit_modifiers;          \
         LOG_DBG("Modifiers set to 0x%02X", keyboard_report.body.modifiers);                        \
     }
 

--- a/app/tests/mod-morph/default_mask_no_implicit/events.patterns
+++ b/app/tests/mod-morph/default_mask_no_implicit/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_register_mod/reg/p
+s/.*hid_unregister_mod/unreg/p
+s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p

--- a/app/tests/mod-morph/default_mask_no_implicit/events.patterns
+++ b/app/tests/mod-morph/default_mask_no_implicit/events.patterns
@@ -1,4 +1,8 @@
-s/.*hid_listener_keycode_//p
-s/.*hid_register_mod/reg/p
-s/.*hid_unregister_mod/unreg/p
-s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p
+s/.*hid_listener_keycode_pressed.*keycode/--- pressed: keycode/p
+s/.*hid_listener_keycode_released.*keycode/--- released: keycode/p
+s/.*hid_register_mod.*Modifiers set to /reg explicit: Modifiers set to /p
+s/.*hid_unregister_mod.*Modifiers set to /unreg explicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_press.*Modifiers set to /reg implicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_release.*Modifiers set to /unreg implicit: Modifiers set to /p
+s/.*hid_masked_modifiers_set.*Modifiers set to /mask mods: Modifiers set to /p
+s/.*hid_masked_modifiers_clear.*Modifiers set to /unmask mods: Modifiers set to /p

--- a/app/tests/mod-morph/default_mask_no_implicit/keycode_events.snapshot
+++ b/app/tests/mod-morph/default_mask_no_implicit/keycode_events.snapshot
@@ -1,58 +1,46 @@
-pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 1 count 1
-reg: Modifiers set to 0x02
-mods: Modifiers set to 0x02
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x00
-mods: Modifiers set to 0x02
-released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x02
-released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 1 count: 0
-unreg: Modifier 1 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 2 count 1
-reg: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x04
-released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 2 count: 0
-unreg: Modifier 2 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 2 count 1
-reg: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 1 count 1
-reg: Modifiers set to 0x06
-mods: Modifiers set to 0x06
-mods: Modifiers set to 0x04
-pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x04
-mods: Modifiers set to 0x06
-released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x06
-released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 1 count: 0
-unreg: Modifier 1 released
-unreg: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 2 count: 0
-unreg: Modifier 2 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
+--- pressed: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x00
+unmask mods: Modifiers set to 0x00
+--- released: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x02
+reg implicit: Modifiers set to 0x02
+mask mods: Modifiers set to 0x00
+--- pressed: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x00
+unmask mods: Modifiers set to 0x02
+--- released: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x02
+--- released: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x04
+reg implicit: Modifiers set to 0x04
+--- pressed: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x04
+unmask mods: Modifiers set to 0x04
+--- released: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x04
+--- released: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x04
+reg implicit: Modifiers set to 0x04
+--- pressed: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x06
+reg implicit: Modifiers set to 0x06
+mask mods: Modifiers set to 0x04
+--- pressed: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x04
+unmask mods: Modifiers set to 0x06
+--- released: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x06
+--- released: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x04
+unreg implicit: Modifiers set to 0x04
+--- released: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00

--- a/app/tests/mod-morph/default_mask_no_implicit/keycode_events.snapshot
+++ b/app/tests/mod-morph/default_mask_no_implicit/keycode_events.snapshot
@@ -1,0 +1,58 @@
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 1 count 1
+reg: Modifiers set to 0x02
+mods: Modifiers set to 0x02
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+mods: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 1 count: 0
+unreg: Modifier 1 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 2 count 1
+reg: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x04
+released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 2 count: 0
+unreg: Modifier 2 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 2 count 1
+reg: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 1 count 1
+reg: Modifiers set to 0x06
+mods: Modifiers set to 0x06
+mods: Modifiers set to 0x04
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x04
+mods: Modifiers set to 0x06
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x06
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 1 count: 0
+unreg: Modifier 1 released
+unreg: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 2 count: 0
+unreg: Modifier 2 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00

--- a/app/tests/mod-morph/default_mask_no_implicit/native_posix_64.keymap
+++ b/app/tests/mod-morph/default_mask_no_implicit/native_posix_64.keymap
@@ -1,0 +1,56 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+
+&kscan {
+	events = <
+        /* A */
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+
+        /* B */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+
+        /* LALT + A */
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+
+        /* LALT + B */
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};
+
+/ {
+    behaviors {
+        mod_morph: mod_morph {
+            compatible = "zmk,behavior-mod-morph";
+            label = "MOD_MORPH_TEST";
+            #binding-cells = <0>;
+            bindings = <&kp A>, <&kp B>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+        };
+    };
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&kp LEFT_ALT &mod_morph
+				&kp LEFT_SHIFT &kp RIGHT_SHIFT
+			>;
+		};
+	};
+};

--- a/app/tests/mod-morph/default_mask_yes_implicit/events.patterns
+++ b/app/tests/mod-morph/default_mask_yes_implicit/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_register_mod/reg/p
+s/.*hid_unregister_mod/unreg/p
+s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p

--- a/app/tests/mod-morph/default_mask_yes_implicit/events.patterns
+++ b/app/tests/mod-morph/default_mask_yes_implicit/events.patterns
@@ -1,4 +1,8 @@
-s/.*hid_listener_keycode_//p
-s/.*hid_register_mod/reg/p
-s/.*hid_unregister_mod/unreg/p
-s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p
+s/.*hid_listener_keycode_pressed.*keycode/--- pressed: keycode/p
+s/.*hid_listener_keycode_released.*keycode/--- released: keycode/p
+s/.*hid_register_mod.*Modifiers set to /reg explicit: Modifiers set to /p
+s/.*hid_unregister_mod.*Modifiers set to /unreg explicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_press.*Modifiers set to /reg implicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_release.*Modifiers set to /unreg implicit: Modifiers set to /p
+s/.*hid_masked_modifiers_set.*Modifiers set to /mask mods: Modifiers set to /p
+s/.*hid_masked_modifiers_clear.*Modifiers set to /unmask mods: Modifiers set to /p

--- a/app/tests/mod-morph/default_mask_yes_implicit/keycode_events.snapshot
+++ b/app/tests/mod-morph/default_mask_yes_implicit/keycode_events.snapshot
@@ -1,0 +1,58 @@
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 1 count 1
+reg: Modifiers set to 0x02
+mods: Modifiers set to 0x02
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
+mods: Modifiers set to 0x02
+mods: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
+mods: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 1 count: 0
+unreg: Modifier 1 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 2 count 1
+reg: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x04
+released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 2 count: 0
+unreg: Modifier 2 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 2 count 1
+reg: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 1 count 1
+reg: Modifiers set to 0x06
+mods: Modifiers set to 0x06
+mods: Modifiers set to 0x04
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
+mods: Modifiers set to 0x06
+mods: Modifiers set to 0x06
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
+mods: Modifiers set to 0x06
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 1 count: 0
+unreg: Modifier 1 released
+unreg: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 2 count: 0
+unreg: Modifier 2 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00

--- a/app/tests/mod-morph/default_mask_yes_implicit/keycode_events.snapshot
+++ b/app/tests/mod-morph/default_mask_yes_implicit/keycode_events.snapshot
@@ -1,58 +1,46 @@
-pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 1 count 1
-reg: Modifiers set to 0x02
-mods: Modifiers set to 0x02
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
-mods: Modifiers set to 0x02
-mods: Modifiers set to 0x02
-released: usage_page 0x07 keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
-mods: Modifiers set to 0x02
-released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 1 count: 0
-unreg: Modifier 1 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 2 count 1
-reg: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x04
-released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 2 count: 0
-unreg: Modifier 2 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 2 count 1
-reg: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 1 count 1
-reg: Modifiers set to 0x06
-mods: Modifiers set to 0x06
-mods: Modifiers set to 0x04
-pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
-mods: Modifiers set to 0x06
-mods: Modifiers set to 0x06
-released: usage_page 0x07 keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
-mods: Modifiers set to 0x06
-released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 1 count: 0
-unreg: Modifier 1 released
-unreg: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 2 count: 0
-unreg: Modifier 2 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
+--- pressed: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x00
+unmask mods: Modifiers set to 0x00
+--- released: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x02
+reg implicit: Modifiers set to 0x02
+mask mods: Modifiers set to 0x00
+--- pressed: keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
+reg implicit: Modifiers set to 0x02
+unmask mods: Modifiers set to 0x02
+--- released: keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x02
+--- released: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x04
+reg implicit: Modifiers set to 0x04
+--- pressed: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x04
+unmask mods: Modifiers set to 0x04
+--- released: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x04
+--- released: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x04
+reg implicit: Modifiers set to 0x04
+--- pressed: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x06
+reg implicit: Modifiers set to 0x06
+mask mods: Modifiers set to 0x04
+--- pressed: keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
+reg implicit: Modifiers set to 0x06
+unmask mods: Modifiers set to 0x06
+--- released: keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x06
+--- released: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x04
+unreg implicit: Modifiers set to 0x04
+--- released: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00

--- a/app/tests/mod-morph/default_mask_yes_implicit/native_posix_64.keymap
+++ b/app/tests/mod-morph/default_mask_yes_implicit/native_posix_64.keymap
@@ -1,0 +1,56 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+
+&kscan {
+	events = <
+        /* A */
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+
+        /* LSFT + B */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+
+        /* LALT + A */
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+
+        /* LALT + LSFT + B */
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};
+
+/ {
+    behaviors {
+        mod_morph: mod_morph {
+            compatible = "zmk,behavior-mod-morph";
+            label = "MOD_MORPH_TEST";
+            #binding-cells = <0>;
+            bindings = <&kp A>, <&kp LS(B)>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+        };
+    };
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&kp LEFT_ALT &mod_morph
+				&kp LEFT_SHIFT &kp RIGHT_SHIFT
+			>;
+		};
+	};
+};

--- a/app/tests/mod-morph/morph-into-hold-tap/events.patterns
+++ b/app/tests/mod-morph/morph-into-hold-tap/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_register_mod/reg/p
+s/.*hid_unregister_mod/unreg/p
+s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p

--- a/app/tests/mod-morph/morph-into-hold-tap/events.patterns
+++ b/app/tests/mod-morph/morph-into-hold-tap/events.patterns
@@ -1,4 +1,8 @@
-s/.*hid_listener_keycode_//p
-s/.*hid_register_mod/reg/p
-s/.*hid_unregister_mod/unreg/p
-s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p
+s/.*hid_listener_keycode_pressed.*keycode/--- pressed: keycode/p
+s/.*hid_listener_keycode_released.*keycode/--- released: keycode/p
+s/.*hid_register_mod.*Modifiers set to /reg explicit: Modifiers set to /p
+s/.*hid_unregister_mod.*Modifiers set to /unreg explicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_press.*Modifiers set to /reg implicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_release.*Modifiers set to /unreg implicit: Modifiers set to /p
+s/.*hid_masked_modifiers_set.*Modifiers set to /mask mods: Modifiers set to /p
+s/.*hid_masked_modifiers_clear.*Modifiers set to /unmask mods: Modifiers set to /p

--- a/app/tests/mod-morph/morph-into-hold-tap/native_posix_64.keymap
+++ b/app/tests/mod-morph/morph-into-hold-tap/native_posix_64.keymap
@@ -1,0 +1,54 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+
+&kscan {
+	events = <
+        /* B */
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+
+        /* D */
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(0,1,200)
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};
+
+/ {
+    behaviors {
+        mod_morph: mod_morph {
+            compatible = "zmk,behavior-mod-morph";
+            label = "MOD_MORPH_TEST";
+            #binding-cells = <0>;
+            bindings = <&kp A>, <&lt 1 B>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+        };
+
+    };
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&kp LEFT_SHIFT &mod_morph
+				&kp C &none
+			>;
+		};
+
+        second_layer {
+			bindings = <
+				&trans &trans
+				&kp D &none
+			>;
+		};
+	};
+};

--- a/app/tests/mod-morph/morph-into-hold-tap/native_posix_64.keymap
+++ b/app/tests/mod-morph/morph-into-hold-tap/native_posix_64.keymap
@@ -2,16 +2,20 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/kscan_mock.h>
 
+/*
+This test fails when the hold-tap resolves as tap, because &mod_morph is then released
+when the hold-tap decision is made but before the keypress is registered.
+*/
 
 &kscan {
 	events = <
-        /* B */
+        /* Shift + tap &mod_morph --> expect B (but get Shift + B) */
 		ZMK_MOCK_PRESS(0,0,10)
 		ZMK_MOCK_PRESS(0,1,10)
 		ZMK_MOCK_RELEASE(0,1,10)
 		ZMK_MOCK_RELEASE(0,0,10)
 
-        /* D */
+        /* Shift + hold &mod_morph --> expect and get D (no shift) */
 		ZMK_MOCK_PRESS(0,0,10)
 		ZMK_MOCK_PRESS(0,1,200)
 		ZMK_MOCK_PRESS(1,0,10)
@@ -29,6 +33,7 @@
             #binding-cells = <0>;
             bindings = <&kp A>, <&lt 1 B>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
+            masked_mods = <(MOD_LSFT|MOD_RSFT)>;  // same as default, added in case default gets changed
         };
 
     };

--- a/app/tests/mod-morph/morph-into-hold-tap/pending
+++ b/app/tests/mod-morph/morph-into-hold-tap/pending
@@ -1,0 +1,7 @@
+This test fails when the hold-tap resolves as tap. As soon as the hold-tap is scheduled
+to resolve as tap, the mod-morph is registered as released. This triggers the
+`.binding_released` function of the `mod-morph` behavior, clearing the `masked_mods`
+before the actual tap-binding of the `hold-tap` gets registered.
+
+If the hold-tap resolves as hold, the mod-morph is not registered as released, and
+`masked_mods` are cleared correctly.

--- a/app/tests/mod-morph/morph-into-hold-tap/pending
+++ b/app/tests/mod-morph/morph-into-hold-tap/pending
@@ -1,7 +1,7 @@
-This test fails when the hold-tap resolves as tap. As soon as the hold-tap is scheduled
-to resolve as tap, the mod-morph is registered as released. This triggers the
+This test fails when the hold-tap is decided to resolve as tap. In this case, as soon as
+the hold-tap decision is made, the mod-morph is released. This triggers the
 `.binding_released` function of the `mod-morph` behavior, clearing the `masked_mods`
 before the actual tap-binding of the `hold-tap` gets registered.
 
-If the hold-tap resolves as hold, the mod-morph is not registered as released, and
+If the hold-tap is decided to resolve as hold, the mod-morph isn't released, and
 `masked_mods` are cleared correctly.

--- a/app/tests/mod-morph/no_mask_no_implicit/events.patterns
+++ b/app/tests/mod-morph/no_mask_no_implicit/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_register_mod/reg/p
+s/.*hid_unregister_mod/unreg/p
+s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p

--- a/app/tests/mod-morph/no_mask_no_implicit/events.patterns
+++ b/app/tests/mod-morph/no_mask_no_implicit/events.patterns
@@ -1,4 +1,8 @@
-s/.*hid_listener_keycode_//p
-s/.*hid_register_mod/reg/p
-s/.*hid_unregister_mod/unreg/p
-s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p
+s/.*hid_listener_keycode_pressed.*keycode/--- pressed: keycode/p
+s/.*hid_listener_keycode_released.*keycode/--- released: keycode/p
+s/.*hid_register_mod.*Modifiers set to /reg explicit: Modifiers set to /p
+s/.*hid_unregister_mod.*Modifiers set to /unreg explicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_press.*Modifiers set to /reg implicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_release.*Modifiers set to /unreg implicit: Modifiers set to /p
+s/.*hid_masked_modifiers_set.*Modifiers set to /mask mods: Modifiers set to /p
+s/.*hid_masked_modifiers_clear.*Modifiers set to /unmask mods: Modifiers set to /p

--- a/app/tests/mod-morph/no_mask_no_implicit/keycode_events.snapshot
+++ b/app/tests/mod-morph/no_mask_no_implicit/keycode_events.snapshot
@@ -1,0 +1,58 @@
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 1 count 1
+reg: Modifiers set to 0x02
+mods: Modifiers set to 0x02
+mods: Modifiers set to 0x02
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x02
+mods: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 1 count: 0
+unreg: Modifier 1 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 2 count 1
+reg: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x04
+released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 2 count: 0
+unreg: Modifier 2 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 2 count 1
+reg: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 1 count 1
+reg: Modifiers set to 0x06
+mods: Modifiers set to 0x06
+mods: Modifiers set to 0x06
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x06
+mods: Modifiers set to 0x06
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x06
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 1 count: 0
+unreg: Modifier 1 released
+unreg: Modifiers set to 0x04
+mods: Modifiers set to 0x04
+released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 2 count: 0
+unreg: Modifier 2 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00

--- a/app/tests/mod-morph/no_mask_no_implicit/keycode_events.snapshot
+++ b/app/tests/mod-morph/no_mask_no_implicit/keycode_events.snapshot
@@ -1,58 +1,46 @@
-pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 1 count 1
-reg: Modifiers set to 0x02
-mods: Modifiers set to 0x02
-mods: Modifiers set to 0x02
-pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x02
-mods: Modifiers set to 0x02
-released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x02
-released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 1 count: 0
-unreg: Modifier 1 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 2 count 1
-reg: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x04
-released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 2 count: 0
-unreg: Modifier 2 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 2 count 1
-reg: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 1 count 1
-reg: Modifiers set to 0x06
-mods: Modifiers set to 0x06
-mods: Modifiers set to 0x06
-pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x06
-mods: Modifiers set to 0x06
-released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x06
-released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 1 count: 0
-unreg: Modifier 1 released
-unreg: Modifiers set to 0x04
-mods: Modifiers set to 0x04
-released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 2 count: 0
-unreg: Modifier 2 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
+--- pressed: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x00
+unmask mods: Modifiers set to 0x00
+--- released: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x02
+reg implicit: Modifiers set to 0x02
+mask mods: Modifiers set to 0x02
+--- pressed: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x02
+unmask mods: Modifiers set to 0x02
+--- released: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x02
+--- released: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x04
+reg implicit: Modifiers set to 0x04
+--- pressed: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x04
+unmask mods: Modifiers set to 0x04
+--- released: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x04
+--- released: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x04
+reg implicit: Modifiers set to 0x04
+--- pressed: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x06
+reg implicit: Modifiers set to 0x06
+mask mods: Modifiers set to 0x06
+--- pressed: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x06
+unmask mods: Modifiers set to 0x06
+--- released: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x06
+--- released: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x04
+unreg implicit: Modifiers set to 0x04
+--- released: keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00

--- a/app/tests/mod-morph/no_mask_no_implicit/native_posix_64.keymap
+++ b/app/tests/mod-morph/no_mask_no_implicit/native_posix_64.keymap
@@ -1,0 +1,57 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+
+&kscan {
+	events = <
+        /* A */
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+
+        /* LSFT + B */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+
+        /* LALT + A */
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+
+        /* LALT + LSFT + B */
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};
+
+/ {
+    behaviors {
+        mod_morph: mod_morph {
+            compatible = "zmk,behavior-mod-morph";
+            label = "MOD_MORPH_TEST";
+            #binding-cells = <0>;
+            bindings = <&kp A>, <&kp B>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+            masked_mods = <0>;
+        };
+    };
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&kp LEFT_ALT &mod_morph
+				&kp LEFT_SHIFT &kp RIGHT_SHIFT
+			>;
+		};
+	};
+};

--- a/app/tests/mod-morph/partial_mask_no_implicit/events.patterns
+++ b/app/tests/mod-morph/partial_mask_no_implicit/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_register_mod/reg/p
+s/.*hid_unregister_mod/unreg/p
+s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p

--- a/app/tests/mod-morph/partial_mask_no_implicit/events.patterns
+++ b/app/tests/mod-morph/partial_mask_no_implicit/events.patterns
@@ -1,4 +1,8 @@
-s/.*hid_listener_keycode_//p
-s/.*hid_register_mod/reg/p
-s/.*hid_unregister_mod/unreg/p
-s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p
+s/.*hid_listener_keycode_pressed.*keycode/--- pressed: keycode/p
+s/.*hid_listener_keycode_released.*keycode/--- released: keycode/p
+s/.*hid_register_mod.*Modifiers set to /reg explicit: Modifiers set to /p
+s/.*hid_unregister_mod.*Modifiers set to /unreg explicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_press.*Modifiers set to /reg implicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_release.*Modifiers set to /unreg implicit: Modifiers set to /p
+s/.*hid_masked_modifiers_set.*Modifiers set to /mask mods: Modifiers set to /p
+s/.*hid_masked_modifiers_clear.*Modifiers set to /unmask mods: Modifiers set to /p

--- a/app/tests/mod-morph/partial_mask_no_implicit/keycode_events.snapshot
+++ b/app/tests/mod-morph/partial_mask_no_implicit/keycode_events.snapshot
@@ -1,0 +1,35 @@
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 1 count 1
+reg: Modifiers set to 0x02
+mods: Modifiers set to 0x02
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+mods: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 1 count: 0
+unreg: Modifier 1 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE5 implicit_mods 0x00 explicit_mods 0x00
+reg: Modifier 5 count 1
+reg: Modifiers set to 0x20
+mods: Modifiers set to 0x20
+mods: Modifiers set to 0x20
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x20
+mods: Modifiers set to 0x20
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x20
+released: usage_page 0x07 keycode 0xE5 implicit_mods 0x00 explicit_mods 0x00
+unreg: Modifier 5 count: 0
+unreg: Modifier 5 released
+unreg: Modifiers set to 0x00
+mods: Modifiers set to 0x00

--- a/app/tests/mod-morph/partial_mask_no_implicit/keycode_events.snapshot
+++ b/app/tests/mod-morph/partial_mask_no_implicit/keycode_events.snapshot
@@ -1,35 +1,29 @@
-pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 1 count 1
-reg: Modifiers set to 0x02
-mods: Modifiers set to 0x02
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x00
-mods: Modifiers set to 0x02
-released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x02
-released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 1 count: 0
-unreg: Modifier 1 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
-pressed: usage_page 0x07 keycode 0xE5 implicit_mods 0x00 explicit_mods 0x00
-reg: Modifier 5 count 1
-reg: Modifiers set to 0x20
-mods: Modifiers set to 0x20
-mods: Modifiers set to 0x20
-pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x20
-mods: Modifiers set to 0x20
-released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
-mods: Modifiers set to 0x20
-released: usage_page 0x07 keycode 0xE5 implicit_mods 0x00 explicit_mods 0x00
-unreg: Modifier 5 count: 0
-unreg: Modifier 5 released
-unreg: Modifiers set to 0x00
-mods: Modifiers set to 0x00
+--- pressed: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x00
+unmask mods: Modifiers set to 0x00
+--- released: keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x02
+reg implicit: Modifiers set to 0x02
+mask mods: Modifiers set to 0x00
+--- pressed: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x00
+unmask mods: Modifiers set to 0x02
+--- released: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x02
+--- released: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00
+--- pressed: keycode 0xE5 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x20
+reg implicit: Modifiers set to 0x20
+mask mods: Modifiers set to 0x20
+--- pressed: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x20
+unmask mods: Modifiers set to 0x20
+--- released: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x20
+--- released: keycode 0xE5 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00

--- a/app/tests/mod-morph/partial_mask_no_implicit/native_posix_64.keymap
+++ b/app/tests/mod-morph/partial_mask_no_implicit/native_posix_64.keymap
@@ -1,0 +1,49 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+
+&kscan {
+	events = <
+        /* A */
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+
+        /* B */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+
+        /* RSFT + B */
+		ZMK_MOCK_PRESS(1,1,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(1,1,10)
+	>;
+};
+
+/ {
+    behaviors {
+        mod_morph: mod_morph {
+            compatible = "zmk,behavior-mod-morph";
+            label = "MOD_MORPH_TEST";
+            #binding-cells = <0>;
+            bindings = <&kp A>, <&kp B>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+            masked_mods = <(MOD_LSFT)>;
+        };
+    };
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&kp LEFT_ALT &mod_morph
+				&kp LEFT_SHIFT &kp RIGHT_SHIFT
+			>;
+		};
+	};
+};

--- a/app/tests/modifiers/mixed/kp-lctl-dn-mod-dn-lctl-up-mod-up/keycode_events.snapshot
+++ b/app/tests/modifiers/mixed/kp-lctl-dn-mod-dn-lctl-up-mod-up/keycode_events.snapshot
@@ -7,7 +7,7 @@ mods: Modifiers set to 0x03
 released: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
 unreg: Modifier 0 count: 0
 unreg: Modifier 0 released
-unreg: Modifiers set to 0x00
+unreg: Modifiers set to 0x02
 mods: Modifiers set to 0x00
 released: usage_page 0x07 keycode 0x05 implicit_mods 0x02 explicit_mods 0x00
 mods: Modifiers set to 0x00

--- a/docs/docs/behaviors/mod-morph.md
+++ b/docs/docs/behaviors/mod-morph.md
@@ -88,3 +88,7 @@ For example, the following configuration morphs `LEFT_SHIFT` + `BACKSPACE` into 
     };
 };
 ```
+
+### Limitations
+
+In some circumstance, when the morphed keycode is a hold-tap, the modifier gets sent along with the hold-tap regardless of the specification of `masked_mods`.

--- a/docs/docs/behaviors/mod-morph.md
+++ b/docs/docs/behaviors/mod-morph.md
@@ -14,12 +14,6 @@ The Mod-Morph behavior sends a different keypress, depending on whether a specif
 
 The Mod-Morph behavior acts as one of two keycodes, depending on if the required modifier is being held during the keypress.
 
-When the modifier is being held it is sent along with the morphed keycode. This can cause problems when the morphed keycode and modifier have an existing relationship (such as `shift-delete` or `ctrl-v` on many operating systems).
-
-As a remedy, you can add the optional attribute `masked_mods`, containing
-the bitwise OR of the modifiers that should be disabled while the key is held,
-so that they are not included in the report sent to the host.
-
 ### Configuration
 
 An example of how to implement the mod-morph "Grave Escape":
@@ -33,12 +27,7 @@ An example of how to implement the mod-morph "Grave Escape":
             #binding-cells = <0>;
             bindings = <&kp ESC>, <&kp GRAVE>;
             mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
-            masked_mods = <(MOD_LGUI|MOD_LSFT)>; // don't send left modifiers
         };
-    };
-
-    keymap {
-        ...
     };
 };
 ```
@@ -75,4 +64,27 @@ Example:
 
 ```
 mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
+```
+
+### Advanced configuration
+
+`masked_mods` 
+
+When a modifier specified in `mods` is being held, it won't be sent along with the morphed keycode if it is also part of `masked_mods`. By default, `masked_mods` equals `mods`.
+
+For example, the following configuration morphs `LEFT_SHIFT` + `BACKSPACE` into `DELETE`, and morphs `RIGHT_SHIFT` + `BACKSPACE` into `RIGHT_SHIFT` + `DELETE`.
+
+```
+/ {
+    behaviors {
+        bspc_del: backspace_delete {
+            compatible = "zmk,behavior-mod-morph";
+            label = "BACKSPACE_DELETE";
+            #binding-cells = <0>;
+            bindings = <&kp BACKSPACE>, <&kp DELETE>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+            masked_mods = <(MOD_LSFT)>;
+        };
+    };
+};
 ```

--- a/docs/docs/behaviors/mod-morph.md
+++ b/docs/docs/behaviors/mod-morph.md
@@ -68,7 +68,7 @@ mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
 
 ### Advanced configuration
 
-`masked_mods` 
+`masked_mods`
 
 When a modifier specified in `mods` is being held, it won't be sent along with the morphed keycode if it is also part of `masked_mods`. By default, `masked_mods` equals `mods`.
 

--- a/docs/docs/behaviors/mod-morph.md
+++ b/docs/docs/behaviors/mod-morph.md
@@ -70,7 +70,7 @@ mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
 
 `masked_mods`
 
-When a modifier specified in `mods` is being held, it won't be sent along with the morphed keycode if it is also part of `masked_mods`. By default, `masked_mods` equals `mods`.
+When a modifier specified in `mods` is being held, it won't be sent along with the morphed keycode if it is also part of `masked_mods`. To sent all modifiers along with the morphed keycode, set `masked_mods` to `<0>`. By default, `masked_mods` equals `mods`.
 
 For example, the following configuration morphs `LEFT_SHIFT` + `BACKSPACE` into `DELETE`, and morphs `RIGHT_SHIFT` + `BACKSPACE` into `RIGHT_SHIFT` + `DELETE`.
 


### PR DESCRIPTION
Small PR to the PR: This prevents masked-mods from masking implicit modifiers.

This enables configs that bind a mod-morph to things like `LS(LC(U))`. The proposed change will send implicitly specified modifiers even when included in the `masked_mods` argument. There are two advantages:

1. The current behavior which masks out implicit modifiers that are explicitly specified as part of the binding is unintuitive. See the review comments by @slashfoo on the PR
2. It provides a way to bind macros that (at some point) make use of a masked-mod. This is essential, for example, for implementing shifted/unshifted unicode pairs via ZMK macros (see [here](https://github.com/urob/zmk-nodefree-config#zmk_unicode) for an example)

EDIT: I added a few more additional tweaks to the PR:

* I deleted an used definition of `trigger_mods`
* After discussing it on discord, I set `masked_mods` to `mods` if unspecified by the user. This resolves the issues raised in https://github.com/zmkfirmware/zmk/issues/683
* I updated the docs with the new options

EDIT: Closed after discussing with Pete on discord and deciding that it might be better to open a new PR with the changes. Link to the new PR: https://github.com/zmkfirmware/zmk/pull/1412